### PR TITLE
Backup removed images to imgur

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,11 @@ COPY package.json yarn.lock ./
 RUN yarn install --pure-lockfile --network-timeout 600000
 COPY tsconfig.json /app
 COPY src/ /app/src/
-
-FROM base as builder
-COPY jest.config.js /app
 RUN yarn build
-RUN yarn test dist/
 
 FROM node:14-alpine as prod
 WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install --pure-lockfile --network-timeout 600000 --prod
-COPY --from=builder /app/dist/ ./dist/
+COPY --from=base /app/dist/ ./dist/
 CMD ["node", "/app/dist/start.js"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 1. Set up config file
 
-    1. Make a copy of `config.local.sample.json` called `config.local.json`. The `config.json` files contain IDs for channels, servers, and roles for their respective servers. You will need to change the sample values in your `config.local.json` to ones from your test server.
+    1. You will need to update `botConfig` in `helm/citsbot/values.local.yaml` with values from your own test server. Please try avoid committing your changes to this file or revert them before you submit your pull request.
     2. To get IDs go to your discord settings and enable developer mode. The toggle can be found at the bottom of the "Appearance" section under Advanced.
     3. You can now right click on channels, users, roles, etc. to copy their ID which you can put in your `config.local.json` file
 
@@ -32,6 +32,7 @@
 
     1. Create a new file called `.env` in the root directory (next to package.json)
     2. Add the following to it `DISCORD_TOKEN=<your-discord-bot-token-here>` where `<your-discord-bot-token-here>` is your discord bot token that you can find under the Bot section of the discord developer portal. **Do not share this value with anyone.**
+    3. You can also provide `IMGUR_CLIENT_ID` if you would like the anime detector module to backup images to imgur before it removes them. You can follow the instructions [here](https://api.imgur.com/oauth2/addclient) to create the required credentials.
 
 ### Set up Docker and Kubernetes
 
@@ -45,10 +46,12 @@
 #### Linux
 
 1. Run `yarn` to install dependencies for your IDE
-2. Install docker and [minikube](https://minikube.sigs.k8s.io/docs/) using your distro's package manager (`apt`/`pacman`/etc.)
+2. Install docker and [minikube](https://minikube.sigs.k8s.io/docs/) using your distro's package manager (`apt`/`pacman`/etc.).
 3. Install helm by following https://helm.sh/docs/intro/install/
 4. Set the `LOCAL_KUBE_CONTEXT` environment variable to `minikube`
 5. Start a local kubernetes cluster by running `minikube start`
+
+You can also set up a local cluster with [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) if you prefer. You can then set the `LOCAL_KUBE_CONTEXT` environment variable to the name of your cluster.
 
 ### Running tests
 

--- a/helm/citsbot/templates/deployment.yaml
+++ b/helm/citsbot/templates/deployment.yaml
@@ -27,6 +27,11 @@ spec:
                 secretKeyRef:
                   name: citsbot.config.{{ $.Values.environment }}
                   key: token
+            - name: IMGUR_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: citsbot.config.{{ $.Values.environment }}
+                  key: imgurClientId
             - name: CONFIG
               value: {{ .Values.botConfig | toJson | quote }}
       terminationGracePeriodSeconds: 5

--- a/helm/citsbot/templates/secrets.yaml
+++ b/helm/citsbot/templates/secrets.yaml
@@ -26,4 +26,5 @@ metadata:
 type: Opaque
 data:
   token: {{ .Values.localSecrets.token | b64enc }}
+  imgurClientId: {{ .Values.localSecrets.imgurClientId | b64enc }}
 {{ end }}

--- a/helm/citsbot/values.local.yaml
+++ b/helm/citsbot/values.local.yaml
@@ -4,6 +4,7 @@ environment: local
 
 localSecrets:
   token: placeholder
+  imgurClientId: placeholder
 
 botConfig:
   prefix: "!"

--- a/helm/citsbot/values.prod.yaml
+++ b/helm/citsbot/values.prod.yaml
@@ -10,6 +10,8 @@ secrets:
     properties:
       - name: token
         key: projects.citsbot.prod.token
+      - name: imgurClientId
+        key: projects.citsbot.prod.imgurClientId
 
 botConfig:
   prefix: "!"

--- a/helm/citsbot/values.staging.yaml
+++ b/helm/citsbot/values.staging.yaml
@@ -10,6 +10,8 @@ secrets:
     properties:
       - name: token
         key: projects.citsbot.staging.token
+      - name: imgurClientId
+        key: projects.citsbot.staging.imgurClientId
 
 botConfig:
   prefix: "!"

--- a/local-build.sh
+++ b/local-build.sh
@@ -3,7 +3,7 @@
 sh ./local-set-context.sh
 
 VERSION=$(cat ./helm/citsbot/Chart.yaml | grep version | awk '{ print $2 }')
-docker build -t citsbot:${VERSION} . --target dev
+docker build -t citsbot:${VERSION} .
 
 if [[ "$LOCAL_KUBE_CONTEXT" = "minikube" ]]; then
   # minikube uses a separate daemon to the host, so images built on the host need to be transferred to it

--- a/local-start.sh
+++ b/local-start.sh
@@ -12,4 +12,5 @@ BOT_CONFIG_FILE="config.local.json"
 sudo helm upgrade -i citsbot ./helm/citsbot \
   --namespace citsbot --create-namespace \
   -f ./helm/citsbot/values.local.yaml \
-  --set localSecrets.token=$DISCORD_TOKEN
+  --set localSecrets.token=$DISCORD_TOKEN \
+  --set localSecrets.imgurClientId=$IMGUR_CLIENT_ID

--- a/local-stop.sh
+++ b/local-stop.sh
@@ -2,6 +2,4 @@
 
 sh ./local-set-context.sh
 
-if [[ $(sudo helm list -n citsbot | grep citsbot) ]]; then
-    sudo helm uninstall -n citsbot citsbot
-fi
+sudo helm uninstall -n citsbot citsbot || true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "watch": "ts-node-dev --unhandled-rejections=strict ./src/start.ts",
     "build": "tsc --outDir ./dist/",
-    "test": "yarn jest",
+    "test": "yarn jest ./src",
     "lint": "eslint \"src/**/*.ts\" --fix"
   },
   "dependencies": {

--- a/src/domain/anime-detector/reverse-image-search.ts
+++ b/src/domain/anime-detector/reverse-image-search.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { LoggingService } from '../../utils/logging';
 
 const SEARCH_URL = `https://images.google.com/searchbyimage?image_url=`;
-const USER_AGENT = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36`;
+const USER_AGENT = `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36`;
 
 export interface ReverseImageSearchService {
   (imageUrl: string): Promise<string>

--- a/src/domain/anime-detector/upload-image-service.spec.ts
+++ b/src/domain/anime-detector/upload-image-service.spec.ts
@@ -1,0 +1,32 @@
+import nock from 'nock';
+import { imgurImageUploaderService } from './upload-image-service';
+
+describe(`imgur image upload service`, () => {
+  const clientId = `client-123`;
+  const uploadImage = imgurImageUploaderService(clientId);
+  
+  test(`given 200 response > when upload > should return uploaded image url`, async () => {
+    nock(`https://api.imgur.com`, { reqheaders: { 'Accept': `application/json`, 'Authorization': `Client-ID ${clientId}` } })
+      .post(`/3/image`)
+      .reply(200, { data: { link: `https://imgur.local/backup.png` } });
+
+    await expect(uploadImage(`https://discord.local/image.png`)).resolves.toBe(`https://imgur.local/backup.png`);
+  });
+
+  test(`given non-200 response > when upload > should throw`, async () => {
+    nock(`https://api.imgur.com`, { reqheaders: { 'Accept': `application/json`, 'Authorization': `Client-ID ${clientId}` } })
+      .post(`/3/image`)
+      .reply(500, `Something went wrong`);
+
+    await expect(uploadImage(`https://discord.local/image.png`)).rejects.toThrowError(Error(`Failed to upload image to imgur. Got non-200 response code: 500, Something went wrong`));
+  });
+  
+  test(`given 200 response with invalid body > when upload > should throw`, async () => {
+    nock(`https://api.imgur.com`, { reqheaders: { 'Accept': `application/json`, 'Authorization': `Client-ID ${clientId}` } })
+      .post(`/3/image`)
+      .reply(200, { foo: `bar` });
+
+    // eslint-disable-next-line no-useless-escape
+    await expect(uploadImage(`https://discord.local/image.png`)).rejects.toThrowError(Error(`Failed to upload image to imgur. Link not present in response body: {\"foo\":\"bar\"}`));
+  });
+});

--- a/src/domain/anime-detector/upload-image-service.ts
+++ b/src/domain/anime-detector/upload-image-service.ts
@@ -18,7 +18,7 @@ export const imgurImageUploaderService = (
 
     const data = await response.json();
     const imgurLink = data?.data?.link;
-    if (imgurLink === undefined) throw Error(`Failed to upload image to imgur. Link not present in response body: ${JSON.stringify(data)}`);
+    if (typeof imgurLink !== `string`) throw Error(`Failed to upload image to imgur. Link not present in response body: ${JSON.stringify(data)}`);
 
     return imgurLink;
   };

--- a/src/domain/anime-detector/upload-image-service.ts
+++ b/src/domain/anime-detector/upload-image-service.ts
@@ -1,0 +1,24 @@
+import fetch from 'node-fetch';
+
+export interface ImageUploaderService {
+  (imageUrl: string): Promise<string>
+}
+
+export const imgurImageUploaderService = (
+  clientId: string,
+): ImageUploaderService =>
+  async imageUrl => {
+    const response = await fetch(`https://api.imgur.com/3/image`, {
+      method: `POST`,
+      headers: { 'Accept': `application/json`, 'Authorization': `Client-ID ${clientId}` },
+      body: imageUrl,
+    });
+
+    if (!response.ok) throw Error(`Failed to upload image to imgur. Got non-200 response code: ${response.status}, ${await response.text()}`);
+
+    const data = await response.json();
+    const imgurLink = data?.data?.link;
+    if (imgurLink === undefined) throw Error(`Failed to upload image to imgur. Link not present in response body: ${JSON.stringify(data)}`);
+
+    return imgurLink;
+  };

--- a/src/start.ts
+++ b/src/start.ts
@@ -16,12 +16,14 @@ import { animeDetectorService } from './domain/anime-detector/detector-service';
 import { validateAnimeDetectorConfig } from './domain/anime-detector/config';
 import { reverseImageSearchService } from './domain/anime-detector/reverse-image-search';
 import { keywordCounterService } from './domain/anime-detector/keyword-counter';
+import { imgurImageUploaderService } from './domain/anime-detector/upload-image-service';
 
 const env = {
   environment: process.env.ENVIRONMENT as string,
   pushgatewayUrl: process.env.PUSHGATEWAY_URL,
   config: JSON.parse(process.env.CONFIG ?? `{}`),
   discordToken: process.env.DISCORD_TOKEN as string,
+  imgurClientId: process.env.IMGUR_CLIENT_ID as string,
 };
 
 const start = async () => {
@@ -33,7 +35,7 @@ const start = async () => {
     welcomerModule(logger, welcomerEmitter(), validateWelcomerConfig(config.modules.welcomer)),
     cowsayModule(logger, config.prefix, cowsayFormatter(validateCowsayConfig(config.modules.cowsay))),
     reactRolesModule(logger, validateReactRolesConfig(config.modules.reactRoles,config.units), config.units),
-    animeDetectorModule(logger, animeDetectorEmitter(), animeDetectorService(validateAnimeDetectorConfig(config.modules.animeDetector), reverseImageSearchService(logger), keywordCounterService(logger))),
+    animeDetectorModule(logger, animeDetectorEmitter(), animeDetectorService(validateAnimeDetectorConfig(config.modules.animeDetector), reverseImageSearchService(logger), keywordCounterService(logger)), imgurImageUploaderService(env.imgurClientId)),
   ];
 
   const bot = discordBot(logger, env.config.guild, modules);


### PR DESCRIPTION
If an image is hosted by discord itself and the bot removes the message it was uploaded for discord will usually remove the image from it's servers. This meant that the log message we received did not always have the removed image.

This change backs up the image that will be removed to imgur so we can always have access to it in our logs.